### PR TITLE
Add an initial set of playbooks/etc. which can populate consul

### DIFF
--- a/playbooks/de-populate-consul-one.yaml
+++ b/playbooks/de-populate-consul-one.yaml
@@ -1,0 +1,14 @@
+# Use this with single-role.yaml and pass an appropriate key and value.
+---
+
+- name: "Update {{key}} in consul"
+  hosts: consul
+  run_once: true
+  become: true
+  gather_facts: false
+  tags:
+    - consul-kv
+  roles:
+    - role: de-populate-consul
+      kv:
+        - {key: "{{key}}", value: "{{value}}"}

--- a/playbooks/de-populate-consul.yaml
+++ b/playbooks/de-populate-consul.yaml
@@ -9,6 +9,7 @@
     - consul-kv
   roles:
     - role: de-populate-consul
+      cleanup: True
       kv:
         - {key: "configs/{{environment_name}}/amqp/uri", value: "{{amqp_de_uri}}"}
         - {key: "configs/{{environment_name}}/amqp/exchange/name", value: "{{amqp.de.name}}"}

--- a/playbooks/de-populate-consul.yaml
+++ b/playbooks/de-populate-consul.yaml
@@ -1,0 +1,26 @@
+---
+
+- name: "Update keys in consul"
+  hosts: consul
+  run_once: true
+  become: true
+  gather_facts: false
+  tags:
+    - consul-kv
+  roles:
+    - role: de-populate-consul
+      kv:
+        - {key: "configs/{{environment_name}}/amqp/uri", value: "{{amqp_de_uri}}"}
+        - {key: "configs/{{environment_name}}/amqp/exchange/name", value: "{{amqp.de.name}}"}
+        - {key: "configs/{{environment_name}}/amqp/exchange/type", value: "{{amqp.de.type}}"}
+        - {key: "configs/{{environment_name}}/apps/de-callback-uri", value: "{{apps.base}}/callbacks/de-job"}
+        - {key: "configs/{{environment_name}}/de-db/uri", value: "postgresql://{{db_user}}:{{db_password}}@{{db_host}}:{{db_port}}/{{db_name}}?sslmode=disable"}
+        - {key: "configs/{{environment_name}}/irods/user", value: "{{irods.user}}"}
+        - {key: "configs/{{environment_name}}/irods/pass", value: "{{irods.password}}"}
+        - {key: "configs/{{environment_name}}/irods/host", value: "{{irods.host}}"}
+        - {key: "configs/{{environment_name}}/irods/port", value: "{{irods.port}}"}
+        - {key: "configs/{{environment_name}}/irods/base", value: "{{irods.home}}"}
+        - {key: "configs/{{environment_name}}/irods/resc", value: "{{irods.default_resource}}"}
+        - {key: "configs/{{environment_name}}/irods/zone", value: "{{irods.zone}}"}
+        - {key: "configs/{{environment_name}}/porklock/image", value: "discoenv/porklock"}
+        - {key: "configs/{{environment_name}}/porklock/tag", value: "{{docker.tag}}"}

--- a/roles/de-populate-consul/defaults/main.yml
+++ b/roles/de-populate-consul/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+consul_port: 8500
+consul_token: "{% if consul is mapping and 'master_token' in consul %}{{ consul.master_token }}{% endif %}"

--- a/roles/de-populate-consul/tasks/main.yml
+++ b/roles/de-populate-consul/tasks/main.yml
@@ -18,9 +18,18 @@
       host: "localhost"
       port: "{{consul_port}}"
       name: "Temporary key-population token"
-      rules: "{{ kv|map('combine', {'policy': 'write'})|list }}"
+      rules: "{{ kv|map('combine', {'policy': 'write'})|list + [{'key': 'configs/' + environment_name, 'policy': 'write'}] }}"
     register: consul_update_token
     ignore_errors: True
+
+  # using URI because consul_kv doesn't do the right thing recursively deleting
+  - name: "Clear out consul k/v store"
+    uri: url="http://localhost:{{consul_port}}/v1/kv/configs/{{environment_name}}?recurse&{% if consul_update_token and 'token' in consul_update_token %}&token={{consul_update_token.token}}{% endif %}" method=DELETE return_content=yes
+    register: cleanup_return
+    changed_when: cleanup_return.content == "true"
+    when: cleanup
+    tags:
+      - cleanup
 
   - name: "Add or update {{key}}"
     consul_kv:

--- a/roles/de-populate-consul/tasks/main.yml
+++ b/roles/de-populate-consul/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+
+- fail: msg="The kv variable is required by de-populate-consul."
+  when: kv is not defined or kv is not iterable
+
+- block:
+  - name: update python-consul
+    pip: name="python-consul" state="latest"
+  - name: update pyhcl
+    pip: name="pyhcl" state="latest"
+  when: consul_token is not none and consul_token != ""
+
+- block:
+  - name: Allocate a consul ACL token
+    when: consul_token is not none and consul_token != ""
+    consul_acl:
+      mgmt_token: "{{ consul_token }}"
+      host: "localhost"
+      port: "{{consul_port}}"
+      name: "Temporary key-population token"
+      rules: "{{ kv|map('combine', {'policy': 'write'})|list }}"
+    register: consul_update_token
+    ignore_errors: True
+
+  - name: "Add or update {{key}}"
+    consul_kv:
+      key: "{{item.key}}"
+      value: "{{item.value}}"
+      port: "{{consul_port}}"
+      token: "{% if consul_update_token and 'token' in consul_update_token %}{{consul_update_token.token}}{% else %}{{ none }}{% endif %}"
+    with_items: "{{kv}}"
+
+  always:
+    - name: "Remove consul ACL token"
+      consul_acl:
+        mgmt_token: "{{ consul_token }}"
+        host: "localhost"
+        token: "{{consul_update_token.token}}"
+        state: absent
+      when: consul_update_token and 'token' in consul_update_token
+      ignore_errors: True


### PR DESCRIPTION
These only populate what's needed for generating jobservices.yml. See the accompanying jex-adapter pull request for details of how this works on the other end.
