### PR TITLE
Add amqp-uri to anon-files.properties.j2

### DIFF
--- a/roles/util-cfg-service/templates/anon-files.properties.j2
+++ b/roles/util-cfg-service/templates/anon-files.properties.j2
@@ -4,3 +4,4 @@ irods-user = {{ irods.user }}
 irods-password = {{ irods.password }}
 irods-zone = {{ irods.zone }}
 irods-home = {{ irods.home }}
+amqp-uri = {{ amqp_de_uri }}


### PR DESCRIPTION
Adds the amqp-uri setting to anon-files.properties. Used for handling ping requests for now, but could be expanded upon.
