### PR TITLE
Add apps.amqp.uri setting for apps

### DIFF
--- a/roles/util-cfg-service/templates/apps.properties.j2
+++ b/roles/util-cfg-service/templates/apps.properties.j2
@@ -85,3 +85,6 @@ apps.email.app-deletion.subject = Your "%s" app has been administratively deprec
 
 # UI host
 apps.ui.base-url = {{ de.base }}
+
+# AMQP
+apps.amqp.uri = {{ amqp_de_uri }}


### PR DESCRIPTION
Adds the AMQP URI which gets used for handling and emitting events in the apps service.
