### PR TITLE
Make the Agave job status callback URL separately configurable.

### DIFF
--- a/inventories/group_vars/all
+++ b/inventories/group_vars/all
@@ -47,6 +47,7 @@ agave:
   read_timeout: 10000
   page_length: 5000
   oauth_refresh_window: 5
+  job_status_callback: "{{ de.base }}/agave-cb"
   client_key:
   client_secret:
 

--- a/roles/util-cfg-service/templates/apps.properties.j2
+++ b/roles/util-cfg-service/templates/apps.properties.j2
@@ -56,7 +56,7 @@ apps.agave.read-timeout         = {{ agave.read_timeout }}
 apps.agave.page-length          = {{ agave.page_length }}
 
 # Agave callback settings.
-apps.agave.callback-base = {{ de.base }}/agave-cb
+apps.agave.callback-base = {{ agave.job_status_callback }}
 
 # PGP Settings
 apps.pgp.keyring-path = {{ pgp_keyring_path }}


### PR DESCRIPTION
One of our development environments is on a subnet that is not accessible from outside our network, so job status callbacks from Agave do not make it back to the DE. Make the callback url separately configurable so that a separate reverse proxy can be created specifically for this purpose.
