### PR TITLE
Support image-janitor running inside a container

### DIFF
--- a/deploy-all.yaml
+++ b/deploy-all.yaml
@@ -20,7 +20,6 @@
 ############################################
 - include: playbooks/de-rabbitmq-cfg.yml
 - include: playbooks/de-condor-launcher.yml
-- include: playbooks/de-image-janitor.yaml
 - include: playbooks/de-road-runner.yml
 - include: playbooks/de-deploy-services.yaml
 - include: playbooks/de-stop-containers-cleanup.yaml

--- a/inventories/group_vars/all
+++ b/inventories/group_vars/all
@@ -260,6 +260,16 @@ terrain:
   log_file: terrain-docker.log
   max_heap: "{{ max_heap.high }}"
 
+image_janitor:
+  host: "{% if use_overlay %}image-janitor{% else %}{{ groups['image-janitor'][0] }}{% endif %}"
+  port:
+  base: "http://{% if use_overlay %}image-janitor{% else %}{{ groups['image-janitor'][0] }}{% endif %}"
+  compose_service: image_janitor
+  image_name: image-janitor
+  container_name: image-janitor
+  properties_file: jobservices.yml
+  log_file: image-janitor-docker.log
+
 email_smtp_host: 127.0.0.1
 email_smtp_from_address:
 iplant_email:

--- a/inventories/group_vars/all
+++ b/inventories/group_vars/all
@@ -261,9 +261,6 @@ terrain:
   max_heap: "{{ max_heap.high }}"
 
 image_janitor:
-  host: "{% if use_overlay %}image-janitor{% else %}{{ groups['image-janitor'][0] }}{% endif %}"
-  port:
-  base: "http://{% if use_overlay %}image-janitor{% else %}{{ groups['image-janitor'][0] }}{% endif %}"
   compose_service: image_janitor
   image_name: image-janitor
   container_name: image-janitor

--- a/playbooks/de-deploy-services.yaml
+++ b/playbooks/de-deploy-services.yaml
@@ -59,13 +59,12 @@
   gather_facts: false
   tags:
     - services
-    - colored
     - image-janitor
   roles:
     - role: util-notify-chat
       msg: "Deploying image-janitor"
     - role: de-deploy-service
-      deploy_use_color: "{{use_color|default(false)}}"
+      deploy_use_color: false
       has_configs: "{% if use_consul_configs %}{{ false }}{% else %}{{ true }}{% endif %}"
       service_name: "{{image_janitor.compose_service}}"
     - role: util-notify-chat

--- a/playbooks/de-deploy-services.yaml
+++ b/playbooks/de-deploy-services.yaml
@@ -53,6 +53,24 @@
     - role: util-notify-chat
       msg: ":heavy_check_mark: Done deploying data-info"
 
+- name: Redeploy image-janitor
+  hosts: image-janitor:&systems
+  become: true
+  gather_facts: false
+  tags:
+    - services
+    - colored
+    - image-janitor
+  roles:
+    - role: util-notify-chat
+      msg: "Deploying image-janitor"
+    - role: de-deploy-service
+      deploy_use_color: "{{use_color|default(false)}}"
+      has_configs: "{% if use_consul_configs %}{{ false }}{% else %}{{ true }}{% endif %}"
+      service_name: "{{image_janitor.compose_service}}"
+    - role: util-notify-chat
+      msg: ":heavy_check_mark: Done deploying anon-files"
+
 - name: Redeploy iplant-email
   hosts: iplant-email:&systems
   become: true

--- a/playbooks/de-deploy-services.yaml
+++ b/playbooks/de-deploy-services.yaml
@@ -65,10 +65,9 @@
       msg: "Deploying image-janitor"
     - role: de-deploy-service
       deploy_use_color: false
-      has_configs: "{% if use_consul_configs %}{{ false }}{% else %}{{ true }}{% endif %}"
       service_name: "{{image_janitor.compose_service}}"
     - role: util-notify-chat
-      msg: ":heavy_check_mark: Done deploying anon-files"
+      msg: ":heavy_check_mark: Done deploying image-janitor"
 
 - name: Redeploy iplant-email
   hosts: iplant-email:&systems

--- a/playbooks/de-docker-network.yml
+++ b/playbooks/de-docker-network.yml
@@ -1,4 +1,4 @@
-- hosts: services:ui:condor
+- hosts: services:ui
   become: true
   gather_facts: false
   serial: 1

--- a/playbooks/de-docker-network.yml
+++ b/playbooks/de-docker-network.yml
@@ -1,4 +1,4 @@
-- hosts: services:ui
+- hosts: services:ui:condor
   become: true
   gather_facts: false
   serial: 1


### PR DESCRIPTION
Adds the group_vars and the entry in de-deploy-services for image-janitor. The pull request against our internal repository is required.