### PR TITLE
Update anon-files CORS headers to expose more headers

### DIFF
--- a/roles/util-cfg-service/templates/ui/nginx.conf.j2
+++ b/roles/util-cfg-service/templates/ui/nginx.conf.j2
@@ -77,7 +77,8 @@ http {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+            add_header 'Access-Control-Allow-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+            add_header 'Access-Control-Expose-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Araport is asking for this to be added; technically, Access-Control-Allow-Headers is just a list of headers which a preflight request returns, specifying what will be allowed later, where Access-Control-Expose-Headers is what's used on an *actual* request to determine what's considered a safe header. I've removed "X-CustomHeader" from the list, which was clearly copied from an example somewhere and isn't meaningful. Otherwise, the two headers list the same, as it should be as far as I can understand from the spec.