### PR TITLE
CORE-8417 Add de-init-tool-permissions role.

### DIFF
--- a/roles/de-init-tool-permissions/.travis.yaml
+++ b/roles/de-init-tool-permissions/.travis.yaml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yaml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/de-init-tool-permissions/README.md
+++ b/roles/de-init-tool-permissions/README.md
@@ -1,0 +1,36 @@
+de-init-tool-permissions
+=======================
+
+Registers existing tools in the DE database in the permissions service.
+All existing tools are considered public by the underlying utility,
+which grants everyone in the de-users group `read` permissions on every tool.
+
+Role Variables
+--------------
+
+| Name                   | Description                     | Required | Default                           |
+| docker_tag             | Docker tag name                 | No       | {{ docker.tag | default(dev) }}   |
+| tool_registration_repo | Tool registration docker repo   | No       | discoenv/tool-registration        |
+| config_image_name      | Configuration docker image name | No       | de-configs-{{ environment_name }} |
+| config_repo            | Configuration docker repo       | No       | {{ docker.registry.base }}/{{ config_image_name }} |
+| config_path            | Configuration path              | No       | /etc/iplant/de/permissions.yaml   |
+| de_database_name       | Name of the DE database         | No       | {{ db_name }}                     |
+
+Example Playbook
+----------------
+
+    ---
+    - name: initialize tool permissions
+      hosts: permissions:&systems
+      become: true
+      gather_facts: false
+      tags:
+        - services
+        - permissions
+      roles:
+        - role: de-init-tool-permissions
+
+License
+-------
+
+BSD

--- a/roles/de-init-tool-permissions/defaults/main.yml
+++ b/roles/de-init-tool-permissions/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+docker_tag: "{{ docker.tag | default(dev) }}"
+tool_registration_repo: "discoenv/tool-registration"
+config_image_name: "de-configs-{{ environment_name }}"
+config_repo: "{{ docker.registry.base }}/{{ config_image_name }}"
+config_path: "/etc/iplant/de/permissions.yaml"
+de_database_name: "{{ db_name }}"

--- a/roles/de-init-tool-permissions/meta/main.yml
+++ b/roles/de-init-tool-permissions/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: Dennis Roberts, Paul Sarando
+  description: Role to register existing DE tools in the DE permissions database.
+  company: CyVerse
+  license: BSD
+
+  min_ansible_version: 1.2
+
+  platforms:
+  - name: EL
+    versions:
+    - 7
+
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/de-init-tool-permissions/tasks/main.yml
+++ b/roles/de-init-tool-permissions/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: install docker-py
+  pip: name="docker-py" state="present"
+
+- name: pull the tool registration docker image
+  shell: docker pull {{tool_registration_repo}}:{{docker_tag}}
+
+- name: pull the configuration docker image
+  shell: docker pull {{config_repo}}:{{docker_tag}}
+
+- name: delete the configuration container if it exists
+  shell: docker rm tool-registration-configs || echo "good, no leftover containers"
+
+- name: create the configuration container
+  shell: docker create --name tool-registration-configs {{config_repo}}:{{docker_tag}}
+
+- name: register existing DE tools
+  shell: >-
+    docker run --rm --volumes-from tool-registration-configs {{ tool_registration_repo }}:{{ docker_tag }}
+    --config={{ config_path }} --de-database-name={{ de_database_name }}
+
+- name: remove the tool registration config container
+  shell: docker rm tool-registration-configs

--- a/roles/de-init-tool-permissions/tests/inventory
+++ b/roles/de-init-tool-permissions/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/de-init-tool-permissions/tests/test.yaml
+++ b/roles/de-init-tool-permissions/tests/test.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - de-init-tool-permissions


### PR DESCRIPTION
Adds a role to register existing DE tools in the DE permissions database with the `tool-registration` conversion utility added by cyverse-de/permissions#5.