### PR TITLE
CORE-7002: removed the configurable LDAP group source name

### DIFF
--- a/inventories/group_vars/all
+++ b/inventories/group_vars/all
@@ -344,7 +344,6 @@ grouper:
         - server_name: "{{ nginx_ssl.server_name }}"
           return: "https://$host$request_uri"
   loader:
-    name: groupSource
     url:
     user:
     pass:

--- a/roles/grouper-config/templates/grouper-loader.properties.j2
+++ b/roles/grouper-config/templates/grouper-loader.properties.j2
@@ -31,6 +31,6 @@ loader.ldap.defaultGroupFolder = ldap:groups
 #################################
 
 # The subject source URL.
-ldap.{{ grouper.loader.name }}.url = {{ grouper.loader.url }}
-ldap.{{ grouper.loader.name }}.user = {{ grouper.loader.user }}
-ldap.{{ grouper.loader.name }}.pass = {{ grouper.loader.pass }}
+ldap.groupSource.url = {{ grouper.loader.url }}
+ldap.groupSource.user = {{ grouper.loader.user }}
+ldap.groupSource.pass = {{ grouper.loader.pass }}


### PR DESCRIPTION
Removed the LDAP loader name definition group variable, which wouldn't really add any additional configurability without some rework in sharkbait as well.