### PR TITLE
CORE-7002: don't use case-sensitive user ID searches, which have a pe…

### DIFF
--- a/roles/grouper-config/templates/sources.xml.j2
+++ b/roles/grouper-config/templates/sources.xml.j2
@@ -127,7 +127,7 @@ Grouper's subject resolver configuration
         <param>
             <param-name>filter</param-name>
             <param-value>
-                (&amp; (uid:caseExactMatch:=%TERM%) (objectclass=person))
+                (&amp; (uid=%TERM%) (objectclass=person))
             </param-value>
         </param>
         <param>
@@ -149,7 +149,7 @@ Grouper's subject resolver configuration
         <param>
             <param-name>filter</param-name>
             <param-value>
-                (&amp; (uid:caseExactmatch:=%TERM%) (objectclass=person))
+                (&amp; (uid=%TERM%) (objectclass=person))
             </param-value>
         </param>
         <param>


### PR DESCRIPTION
…rformance penalty, in Grouper's LDAP searches

This change is tiny, so I'm going to merge it immediately. Anyone who wants to review it is welcome to do so, however.

The primary reason for switching to case-sensitive user lookups was because users were logging into CAS using mixed-case usernames, which was causing problems in the DE because the usernames that were being sent from CAS did not match the usernames stored in other parts of the system. Using a case-sensitive match in CAS still makes sense, but Grouper has to do a lot more username lookups, so it makes sense to make these searches as performant as possible. The case-sensitive searches come with a significant performance cost, so removing them from grouper searches is necessary.
