### PR TITLE
Refactor Elasticsearch Ansible Vars

### DIFF
--- a/inventories/group_vars/all/data_store.yml
+++ b/inventories/group_vars/all/data_store.yml
@@ -1,8 +1,0 @@
----
-data_store:
-  elasticsearch:
-    host: "{{ groups['data-store-elasticsearch'][0] }}"
-    port:
-    scroll_size: 1000
-    data_index: data
-

--- a/inventories/group_vars/all/elasticsearch.yml
+++ b/inventories/group_vars/all/elasticsearch.yml
@@ -1,0 +1,12 @@
+---
+elasticsearch_uri: "{{elasticsearch.scheme}}://{{elasticsearch.host}}:{{elasticsearch.port}}"
+elasticsearch:
+  scheme: "http"
+  host: "{{ groups['data-store-elasticsearch'][0] }}"
+  port:
+  batch_size: 1000
+  scroll_size: 1000
+  indices:
+     data:
+        name: data
+        alias: data

--- a/inventories/group_vars/all/elasticsearch.yml
+++ b/inventories/group_vars/all/elasticsearch.yml
@@ -4,6 +4,8 @@ elasticsearch:
   scheme: "http"
   host: "{{ groups['data-store-elasticsearch'][0] }}"
   port:
+  username:
+  password:
   batch_size: 1000
   scroll_size: 1000
   indices:

--- a/playbooks/de-populate-consul.yaml
+++ b/playbooks/de-populate-consul.yaml
@@ -47,13 +47,16 @@
         - {key: "configs/{{environment_name}}/icat/user", value: "{{icat.user}}"}
         - {key: "configs/{{environment_name}}/icat/password", value: "{{icat.password}}"}
         - {key: "configs/{{environment_name}}/icat/db", value: "{{icat.db}}"}
-        - {key: "configs/{{environment_name}}/elasticsearch/base", value: "http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}"}
-        - {key: "configs/{{environment_name}}/elasticsearch/host", value: "{{ data_store.elasticsearch.host }}"}
-        - {key: "configs/{{environment_name}}/elasticsearch/port", value: "{{ data_store.elasticsearch.port }}"}
-        - {key: "configs/{{environment_name}}/elasticsearch/data-index", value: "{{ data_store.elasticsearch.data_index }}"}
-        - {key: "configs/{{environment_name}}/elasticsearch/data-alias", value: "data"}
-        - {key: "configs/{{environment_name}}/elasticsearch/scroll-size", value: "1000"}
-        - {key: "configs/{{environment_name}}/elasticsearch/batch-size", value: "1000"}
+        - {key: "configs/{{environment_name}}/elasticsearch/base", value: "{{elasticsearch_uri}}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/uri", value: "{{elasticsearch_uri}}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/host", value: "{{ elasticsearch.host }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/port", value: "{{ elasticsearch.port }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/data-index", value: "{{ elasticsearch.indices.data.name }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/data-alias", value: "{{elasticsearch.indices.data.alias}}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/indices/data/name", value: "{{ elasticsearch.indices.data.name }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/indices/data/alias", value: "{{elasticsearch.indices.data.alias}}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/scroll-size", value: "{{elasticsearch.scroll_size}}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/batch-size", value: "{{elasticseach.batch_size}}"}
         - {key: "configs/{{environment_name}}/grouper/base", value: "{{ grouper.ws.base_url }}"}
         - {key: "configs/{{environment_name}}/grouper/api-version", value: "{{ iplant_groups.grouper.api_version }}"}
         - {key: "configs/{{environment_name}}/grouper/user", value: "{{ grouper.admin.user }}"}

--- a/playbooks/de-populate-consul.yaml
+++ b/playbooks/de-populate-consul.yaml
@@ -51,6 +51,8 @@
         - {key: "configs/{{environment_name}}/elasticsearch/uri", value: "{{elasticsearch_uri}}"}
         - {key: "configs/{{environment_name}}/elasticsearch/host", value: "{{ elasticsearch.host }}"}
         - {key: "configs/{{environment_name}}/elasticsearch/port", value: "{{ elasticsearch.port }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/username", value: "{{ elasticsearch.username }}"}
+        - {key: "configs/{{environment_name}}/elasticsearch/password", value: "{{ elasticsearch.password }}"}
         - {key: "configs/{{environment_name}}/elasticsearch/data-index", value: "{{ elasticsearch.indices.data.name }}"}
         - {key: "configs/{{environment_name}}/elasticsearch/data-alias", value: "{{elasticsearch.indices.data.alias}}"}
         - {key: "configs/{{environment_name}}/elasticsearch/indices/data/name", value: "{{ elasticsearch.indices.data.name }}"}

--- a/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/roles/util-cfg-service/templates/dewey.properties.j2
@@ -8,6 +8,7 @@ dewey.amqp.qos                  = 100
 
 dewey.events.amqp.uri           = {{ amqp_de_uri }}
 
+dewey.es.uri                    = {{ elasticsearch_uri }}
 dewey.es.host                   = {{ elasticsearch.host }}
 dewey.es.port                   = {{ elasticsearch.port }}
 dewey.es.username               = {{ elasticsearch.username }}

--- a/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/roles/util-cfg-service/templates/dewey.properties.j2
@@ -8,8 +8,9 @@ dewey.amqp.qos                  = 100
 
 dewey.events.amqp.uri           = {{ amqp_de_uri }}
 
-dewey.es.host                   = {{ data_store.elasticsearch.host }}
-dewey.es.port                   = {{ data_store.elasticsearch.port }}
+dewey.es.host                   = {{ elasticsearch.host }}
+dewey.es.port                   = {{ elasticsearch.port }}
+dewey.es.index                  = {{ elasticsearch.indices.data.alias }}
 
 dewey.irods.host                = {{ irods.host }}
 dewey.irods.port                = {{ irods.port }}

--- a/roles/util-cfg-service/templates/dewey.properties.j2
+++ b/roles/util-cfg-service/templates/dewey.properties.j2
@@ -10,6 +10,8 @@ dewey.events.amqp.uri           = {{ amqp_de_uri }}
 
 dewey.es.host                   = {{ elasticsearch.host }}
 dewey.es.port                   = {{ elasticsearch.port }}
+dewey.es.username               = {{ elasticsearch.username }}
+dewey.es.password               = {{ elasticsearch.password }}
 dewey.es.index                  = {{ elasticsearch.indices.data.alias }}
 
 dewey.irods.host                = {{ irods.host }}

--- a/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -1,6 +1,8 @@
 # ElasticSearch Settings
 infosquito.es.host        = {{ elasticsearch.host }}
 infosquito.es.port        = {{ elasticsearch.port }}
+infosquito.es.username    = {{ elasticsearch.username }}
+infosquito.es.password    = {{ elasticsearch.password }}
 infosquito.es.index       = {{ elasticsearch.indices.data.alias }}
 infosquito.es.scroll-size = {{ elasticsearch.scroll_size }}
 

--- a/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -1,4 +1,5 @@
 # ElasticSearch Settings
+infosquito.es.uri         = {{ elasticsearch_uri }}
 infosquito.es.host        = {{ elasticsearch.host }}
 infosquito.es.port        = {{ elasticsearch.port }}
 infosquito.es.username    = {{ elasticsearch.username }}

--- a/roles/util-cfg-service/templates/infosquito.properties.j2
+++ b/roles/util-cfg-service/templates/infosquito.properties.j2
@@ -1,8 +1,8 @@
 # ElasticSearch Settings
-infosquito.es.host        = {{ data_store.elasticsearch.host }}
-infosquito.es.port        = {{ data_store.elasticsearch.port }}
-infosquito.es.index       = {{ data_store.elasticsearch.data_index }}
-infosquito.es.scroll-size = {{ data_store.elasticsearch.scroll_size }}
+infosquito.es.host        = {{ elasticsearch.host }}
+infosquito.es.port        = {{ elasticsearch.port }}
+infosquito.es.index       = {{ elasticsearch.indices.data.alias }}
+infosquito.es.scroll-size = {{ elasticsearch.scroll_size }}
 
 # ICAT Database Connection Settings
 infosquito.icat.host     = {{ icat.host }}

--- a/roles/util-cfg-service/templates/monkey.properties.j2
+++ b/roles/util-cfg-service/templates/monkey.properties.j2
@@ -10,6 +10,8 @@ monkey.amqp.exchange.durable     = {{ amqp.de.durable }}
 monkey.amqp.exchange.auto-delete = {{ amqp.de.auto_delete }}
 
 monkey.es.url            = {{ elasticsearch_uri }}
+monkey.es.username       = {{ elasticsearch.username }}
+monkey.es.password       = {{ elasticsearch.password }}
 monkey.es.index          = {{ elasticsearch.indices.data.alias }}
 monkey.es.tag-type       = tag
 monkey.es.batch-size     = {{ elasticsearch.batch_size }}

--- a/roles/util-cfg-service/templates/monkey.properties.j2
+++ b/roles/util-cfg-service/templates/monkey.properties.j2
@@ -9,11 +9,11 @@ monkey.amqp.exchange.name        = {{ amqp.de.name }}
 monkey.amqp.exchange.durable     = {{ amqp.de.durable }}
 monkey.amqp.exchange.auto-delete = {{ amqp.de.auto_delete }}
 
-monkey.es.url            = http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
-monkey.es.index          = data
+monkey.es.url            = {{ elasticsearch_uri }}
+monkey.es.index          = {{ elasticsearch.indices.data.alias }}
 monkey.es.tag-type       = tag
-monkey.es.batch-size     = 1000
-monkey.es.scroll-size    = {{ data_store.elasticsearch.scroll_size }}
+monkey.es.batch-size     = {{ elasticsearch.batch_size }}
+monkey.es.scroll-size    = {{ elasticsearch.scroll_size }}
 monkey.es.scroll-timeout = 1m
 
 monkey.tags.host       = {{ metadata_db_host }}

--- a/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
+++ b/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
@@ -6,6 +6,8 @@ amqp:
 
 elasticsearch:
   base: {{ elasticsearch_uri }}
+  username: {{ elasticsearch.username }}
+  password: {{ elasticsearch.password }}
   index: {{ elasticsearch.indices.data.alias }}
 
 db:

--- a/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
+++ b/roles/util-cfg-service/templates/templeton-incremental.yaml.j2
@@ -5,8 +5,8 @@ amqp:
     type: {{amqp.de.type}}
 
 elasticsearch:
-  base: http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
-  index: {{ data_store.elasticsearch.data_index }}
+  base: {{ elasticsearch_uri }}
+  index: {{ elasticsearch.indices.data.alias }}
 
 db:
   uri: postgres://{{ metadata_db_user }}:{{ metadata_db_password }}@{{ metadata_db_host }}:{{ metadata_db_port }}/{{ metadata_db_name }}?sslmode=disable

--- a/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
+++ b/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
@@ -6,6 +6,8 @@ amqp:
 
 elasticsearch:
   base: {{ elasticsearch_uri }}
+  username: {{ elasticsearch.username }}
+  password: {{ elasticsearch.password }}
   index: {{ elasticsearch.indices.data.alias }}
 
 db:

--- a/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
+++ b/roles/util-cfg-service/templates/templeton-periodic.yaml.j2
@@ -5,8 +5,8 @@ amqp:
     type: {{amqp.de.type}}
 
 elasticsearch:
-  base: http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
-  index: {{ data_store.elasticsearch.data_index }}
+  base: {{ elasticsearch_uri }}
+  index: {{ elasticsearch.indices.data.alias }}
 
 db:
   uri: postgres://{{ metadata_db_user }}:{{ metadata_db_password }}@{{ metadata_db_host }}:{{ metadata_db_port }}/{{ metadata_db_name }}?sslmode=disable

--- a/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/roles/util-cfg-service/templates/terrain.properties.j2
@@ -55,6 +55,8 @@ terrain.tree-viewer.base-url = {{ tree_parser_base }}
 
 # Data-Store Elastic Search settings
 terrain.infosquito.es-url = {{ elasticsearch_uri }}
+terrain.es.username       = {{ elasticsearch.username }}
+terrain.es.password       = {{ elasticsearch.password }}
 terrain.es.index          = {{ elasticsearch.indices.data.alias }}
 
 # App execution settings

--- a/roles/util-cfg-service/templates/terrain.properties.j2
+++ b/roles/util-cfg-service/templates/terrain.properties.j2
@@ -54,7 +54,8 @@ terrain.jex.base-url = {{ jex.base }}/
 terrain.tree-viewer.base-url = {{ tree_parser_base }}
 
 # Data-Store Elastic Search settings
-terrain.infosquito.es-url = http://{{ data_store.elasticsearch.host }}:{{ data_store.elasticsearch.port }}
+terrain.infosquito.es-url = {{ elasticsearch_uri }}
+terrain.es.index          = {{ elasticsearch.indices.data.alias }}
 
 # App execution settings
 terrain.job-exec.default-output-folder = {{ apps.out_dir }}


### PR DESCRIPTION
The `data_store` dictionary was removed in favor of the `elasticsearch` dictionary. Corresponding Ansible templates in [playbooks/de-populate-consul.yaml](playbooks/de-populate-consul.yaml) and [roles/util-cfg-service/templates/](roles/util-cfg-service/templates/).

All configuration files which take an Elasticsearch index, are now using the configured `elasticsearch.indices.[INDEX].alias` in lieu of the true index name.

Other Elasticsearch-related variables have been added as well. 