### PR TITLE
CORE-8802: add anon-files-nginx and kifshare-nginx info to comments in UI nginx template

### DIFF
--- a/roles/util-cfg-service/templates/ui/nginx.conf.tmpl.j2
+++ b/roles/util-cfg-service/templates/ui/nginx.conf.tmpl.j2
@@ -10,6 +10,22 @@
 # * ({{.CheckID}} {{.Status}}: {{.Output | replaceAll "\n" "\n#"}})
 {{- end }}
 {{- end }}
+# Below here, we've got the anon-files-nginx and kifshare-nginx checks. Having
+# them here is relevant because they're used in this file, but more importantly
+# it means that if their IP addresses or health checks change, it'll result in
+# a configuration reload, which will clear nginx's cache of their IP addresses.
+{{- range service "anon-files-nginx" "any" }}
+# {{.ID}} {{.Address}}:{{.Port}} {{.Tags}}
+{{- range .Checks }}
+# * ({{.CheckID}} {{.Status}}: {{.Output | replaceAll "\n" "\n#"}})
+{{- end }}
+{{- end }}
+{{- range service "kifshare-nginx" "any" }}
+# {{.ID}} {{.Address}}:{{.Port}} {{.Tags}}
+{{- range .Checks }}
+# * ({{.CheckID}} {{.Status}}: {{.Output | replaceAll "\n" "\n#"}})
+{{- end }}
+{{- end }}
 {% endraw %}
 {% endblock %}
 


### PR DESCRIPTION
This should ensure that the nginx config is reloaded any time the IP addresses or check statuses of these changes, which should prevent some DNS gremlins. See the issue for more details on this.