### PR TITLE
CORE-8386 Add data-info consul configs

### DIFF
--- a/inventories/group_vars/all/kifshare.yml
+++ b/inventories/group_vars/all/kifshare.yml
@@ -1,12 +1,7 @@
 ---
-kifshare_external_url: "https://{{ de.host }}/{{ kifshare.external_url_suffix }}"
-kifshare_external_anon_files_url: "https://{{ de.host }}/{{ kifshare.external_anon_files_suffix }}"
 kifshare:
   host: "{% if use_overlay %}kifshare{% else %}{{ groups['kifshare'][0] }}{% endif %}"
   port:
-  external_url_suffix: dl
-  external_anon_files_suffix: anon-files
-  anon_user: anonymous
   service_name: kifshare.service
   service_name_short: kifshare
   compose_service: kifshare
@@ -15,7 +10,6 @@ kifshare:
   container_name: kifshare
   properties_file: kifshare.properties
   log_file: kifshare-docker.log
-  de_url: \{\{url\}\}/d/\{\{ticket-id\}\}/\{\{filename\}\}
   mode: prod
   download_buffer_size: 100
   max_heap: "{{ max_heap.low }}"

--- a/playbooks/de-data-info.yml
+++ b/playbooks/de-data-info.yml
@@ -12,6 +12,7 @@
       msg: "Deploying data-info"
     - role: de-deploy-service
       deploy_use_color: "use_color|default(false)"
+      has_configs: "{% if use_consul_configs %}{{ false }}{% else %}{{ true }}{% endif %}"
       service_name: "{{data_info.compose_service}}"
     - role: util-notify-chat
       msg: ":heavy_check_mark: Done deploying data-info"

--- a/playbooks/de-populate-consul.yaml
+++ b/playbooks/de-populate-consul.yaml
@@ -61,6 +61,13 @@
         - {key: "configs/{{environment_name}}/irods/base", value: "{{irods.home}}"}
         - {key: "configs/{{environment_name}}/irods/resc", value: "{{irods.default_resource}}"}
         - {key: "configs/{{environment_name}}/irods/zone", value: "{{irods.zone}}"}
+        - {key: "configs/{{environment_name}}/irods/admins", value: "{{irods.admins}}"}
+        - {key: "configs/{{environment_name}}/irods/admin-users", value: "{{irods_admin_users}}"}
+        - {key: "configs/{{environment_name}}/irods/bad-chars", value: "{{irods.bad_chars}}"}
+        - {key: "configs/{{environment_name}}/irods/max-paths-in-request", value: "{{fs_max_paths_in_request}}"}
+        - {key: "configs/{{environment_name}}/irods/max-retries", value: "10"}
+        - {key: "configs/{{environment_name}}/irods/retry-sleep", value: "1000"}
+        - {key: "configs/{{environment_name}}/irods/use-trash", value: "true"}
         - {key: "configs/{{environment_name}}/icat/host", value: "{{icat.host}}"}
         - {key: "configs/{{environment_name}}/icat/port", value: "{{icat.port}}"}
         - {key: "configs/{{environment_name}}/icat/user", value: "{{icat.user}}"}
@@ -124,7 +131,7 @@
         - {key: "configs/{{environment_name}}/kifshare/flags/iget", value: "iget -t \\{\\{ticket-id\\}\\} '\\{\\{abspath\\}\\}'"}
         - {key: "configs/{{environment_name}}/kifshare/css-files", value: "resources/css/reset.css,resources/css/960.css,resources/css/kif.css"}
         - {key: "configs/{{environment_name}}/kifshare/javascript-files", value: "https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js,https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.0/mustache.min.js,resources/js/json2.js,resources/js/kif.js"}
-        - {key: "configs/{{environment_name}}/de/base", value: "{{ de.base }}"}
+        - {key: "configs/{{environment_name}}/tree-urls/base", value: "http://{{ tree_urls.host }}:{{ tree_urls.port }}"}
         - {key: "configs/{{environment_name}}/tree-urls/cleanup/age", value: "{{ tree_urls.cleanup_age }}"}
         - {key: "configs/{{environment_name}}/tree-urls/cleanup/start", value: "{{ tree_urls.cleanup_start }}"}
         - {key: "configs/{{environment_name}}/tree-urls/cleanup/enable", value: "{{ tree_urls.cleanup_enable }}"}
@@ -140,6 +147,7 @@
         - {key: "configs/{{environment_name}}/infosquito/job-indexing-enabled", value: "{{ infosquito.job_indexing_enabled }}"}
         - {key: "configs/{{environment_name}}/infosquito/job-basename", value: "{{ infosquito.job_basename }}"}
         - {key: "configs/{{environment_name}}/infosquito/job-daynum", value: "{{ infosquito.job_daynum }}"}
+        - {key: "configs/{{environment_name}}/de/base", value: "{{ de.base }}"}
         - {key: "configs/{{environment_name}}/de/default-build-number", value: "{{ de_version_name }}"}
         - {key: "configs/{{environment_name}}/de/release-version", value: "{{ de_version }}"}
         - {key: "configs/{{environment_name}}/de/base-url", value: "{{ cas_base }}"}
@@ -192,5 +200,11 @@
         - {key: "configs/{{environment_name}}/jex/base", value: "{{ jex.base }}"}
         - {key: "configs/{{environment_name}}/jex/batch-group", value: "{{ jex.batch_group }}"}
         - {key: "configs/{{environment_name}}/data-info/base", value: "http://{{ data_info.host }}:{{ data_info.port }}"}
+        - {key: "configs/{{environment_name}}/data-info/anon-files-base", value: "https://{{ de.host }}/anon-files"}
+        - {key: "configs/{{environment_name}}/data-info/anon-user", value: "anonymous"}
+        - {key: "configs/{{environment_name}}/data-info/copy-key", value: "ipc-de-copy-from"}
+        - {key: "configs/{{environment_name}}/data-info/community-data", value: "{{irods.home}}/shared"}
+        - {key: "configs/{{environment_name}}/data-info/kifshare-external-url", value: "https://{{ de.host }}/dl"}
+        - {key: "configs/{{environment_name}}/data-info/type-detect-attribute", value: "ipc-filetype"}
         - {key: "configs/{{environment_name}}/templeton/amqp-queue-prefix", value: "{{ templeton.amqp.queue_prefix }}"}
 

--- a/roles/util-cfg-service/templates/data-info.properties.j2
+++ b/roles/util-cfg-service/templates/data-info.properties.j2
@@ -1,13 +1,13 @@
-data-info.anon-files-base-url        = {{ kifshare_external_anon_files_url }}
-data-info.anon-user                  = {{ kifshare.anon_user }}
+data-info.anon-files-base-url        = https://{{ de.host }}/anon-files
+data-info.anon-user                  = anonymous
 data-info.bad-chars                  = {{ irods.bad_chars }}
 data-info.community-data             = {{ irods.home }}/shared
 data-info.copy-key                   = ipc-de-copy-from
 data-info.max-paths-in-request       = {{ fs_max_paths_in_request }}
 data-info.metadata.base-url          = http://{{ metadata.host }}:{{ metadata.port }}
 data-info.tree-urls.base-url         = http://{{ tree_urls.host }}:{{ tree_urls.port }}
-data-info.kifshare-download-template = {{ kifshare.de_url }}
-data-info.kifshare-external-url      = {{ kifshare_external_url }}
+data-info.kifshare-download-template = \{\{url\}\}/d/\{\{ticket-id\}\}/\{\{filename\}\}
+data-info.kifshare-external-url      = https://{{ de.host }}/dl
 data-info.perms-filter               = {{ irods.admins }}
 data-info.port                       = {{ default_service_port }}
 


### PR DESCRIPTION
This PR adds consul configs to the `de-populate-consul.yaml` playbook for the data-info service and the `has_configs` setting to the `de-data-info.yml` playbook.

It also includes a commit that cleans-up kifshare group_vars and the original `data-info.properties.j2` config template.