### PR TITLE
Multi host zero downtime changes

### DIFF
--- a/playbooks/de-rm-containers-cleanup.yaml
+++ b/playbooks/de-rm-containers-cleanup.yaml
@@ -83,3 +83,17 @@
       ignore_errors: yes
       become: true
       shell: docker rm -fv etc_config_anon_files_1
+
+- name: Remove old 'etc' project containers
+  hosts: services:ui:image-janitor:consul:!grouper
+  become: true
+  gather_facts: false
+  tags:
+    - services
+    - ui
+  post_tasks:
+    - name: Stop all containers with 'etc' docker-compose project
+      shell: docker stop $(docker ps -qf "label=com.docker.compose.project=etc")
+
+    - name: Remove all containers with 'etc' docker-compose project
+      shell: docker rm -fv $(docker ps -qf "label=com.docker.compose.project=etc")

--- a/playbooks/de-rm-containers-cleanup.yaml
+++ b/playbooks/de-rm-containers-cleanup.yaml
@@ -93,7 +93,9 @@
     - ui
   post_tasks:
     - name: Stop all containers with 'etc' docker-compose project
+      ignore_errors: yes
       shell: docker stop $(docker ps -qf "label=com.docker.compose.project=etc")
 
     - name: Remove all containers with 'etc' docker-compose project
+      ignore_errors: yes
       shell: docker rm -fv $(docker ps -qf "label=com.docker.compose.project=etc")

--- a/roles/de-deploy-service/tasks/main.yaml
+++ b/roles/de-deploy-service/tasks/main.yaml
@@ -13,6 +13,7 @@
     DE_TAG: "{{docker.tag}}"
     DE_ENV: "{{environment_name}}"
     HOSTNAME: "{{ hostname_i.stdout_lines[0] }}"
+    COMPOSE_PROJECT_NAME: "{{ inventory_hostname_short }}"
   shell: "docker-compose -f {{docker_compose_path}} config --services"
   register: service_list
   tags:

--- a/roles/de-deploy-service/tasks/swap-service.yaml
+++ b/roles/de-deploy-service/tasks/swap-service.yaml
@@ -13,6 +13,7 @@
     DE_TAG: "{{docker.tag}}"
     DE_ENV: "{{environment_name}}"
     HOSTNAME: "{{ hostname_i.stdout_lines[0] }}"
+    COMPOSE_PROJECT_NAME: "{{ inventory_hostname_short }}"
     CONSUL_TOKEN: "{{(inventory_hostname+environment_name+consul.get('salt', 'consul_salt')) | to_uuid}}"
 
 - block:
@@ -86,4 +87,5 @@
     DE_TAG: "{{docker.tag}}"
     DE_ENV: "{{environment_name}}"
     HOSTNAME: "{{ hostname_i.stdout_lines[0] }}"
+    COMPOSE_PROJECT_NAME: "{{ inventory_hostname_short }}"
     CONSUL_TOKEN: "{{(inventory_hostname+environment_name+consul.get('salt', 'consul_salt')) | to_uuid}}"

--- a/roles/de-deploy-service/tasks/uncolored.yaml
+++ b/roles/de-deploy-service/tasks/uncolored.yaml
@@ -37,4 +37,5 @@
     DE_TAG: "{{docker.tag}}"
     DE_ENV: "{{environment_name}}"
     HOSTNAME: "{{ hostname_i.stdout_lines[0] }}"
+    COMPOSE_PROJECT_NAME: "{{ inventory_hostname_short }}"
     CONSUL_TOKEN: "{% if consul is defined %}{{(inventory_hostname+environment_name+consul.get('salt', 'consul_salt')) | to_uuid}}{% endif %}"


### PR DESCRIPTION
First commit adds the docker-compose project name to all the deployment stuff. This is needed so that the container names are unique across hosts.

Second commit makes sure that we have something in place which will stop and remove containers using the old `etc` project.

See also the companion private ansible PR.