### PR TITLE
Playbook to enable or disable Agave integration in the DE.

### DIFF
--- a/playbooks/de-agave.yml
+++ b/playbooks/de-agave.yml
@@ -1,0 +1,36 @@
+---
+- name: "verify variables"
+  hosts: consul
+  gather_facts: false
+  pre_tasks:
+    - fail: msg="this playbook is only compatible with environments using Consul configs"
+      when: not use_consul_configs | bool
+    - fail: msg="the agave_enabled variable must be specified"
+      when: not agave_enabled is defined
+    - fail: msg="this playbook does not apply to environments where Agave integration is disabled"
+      when: not features.agave | bool
+
+- name: "update configs"
+  hosts: consul
+  run_once: true
+  become: true
+  gather_facts: false
+  roles:
+    - role: util-notify-chat
+      username: Consul
+      icon: ":consul:"
+      msg: "{% if agave_enabled | bool %}Enabling{% else %}Disabling{% endif %} Agave"
+    - role: de-populate-consul
+      cleanup: false
+      kv:
+        - {key: "configs/{{environment_name}}/agave/enabled", value: "{{ agave_enabled }}"}
+        - {key: "configs/{{environment_name}}/agave/jobs-enabled", value: "{{ agave_enabled }}"}
+    - role: util-notify-chat
+      username: Consul
+      icon: ":consul:"
+      msg: "Done {% if agave_enabled | bool %}Enabling{% else %}Disabling{% endif %} Agave"
+
+- name: "restart apps service"
+  include: de-apps.yml
+  vars:
+    pull_images: false

--- a/roles/de-deploy-service/defaults/main.yml
+++ b/roles/de-deploy-service/defaults/main.yml
@@ -5,3 +5,4 @@ service_name_short: "{{service_name|replace('_', '-')}}"
 consul_port: 8500
 consul_token: "{% if consul is mapping and 'master_token' in consul %}{{ consul.master_token }}{% endif %}"
 data_container_service_name: "{{ data_container.compose_service }}"
+pull_images: true

--- a/roles/de-deploy-service/tasks/restart-service.yaml
+++ b/roles/de-deploy-service/tasks/restart-service.yaml
@@ -6,6 +6,7 @@
   register: docker_pull_v
   async: 300
   poll: 0
+  when: pull_images
   tags:
     - docker_pull
     - docker_pull_service
@@ -35,6 +36,10 @@
   async_status: jid={{ docker_pull_v.ansible_job_id }}
   register: docker_pull_res
   until: docker_pull_res.finished
+  when: pull_images
+  tags:
+    - docker_pull
+    - docker_pull_service
   retries: 300
   delay: 1
 


### PR DESCRIPTION
Enable Agave:

```
$ ansible-playbook -i /path/to/inventory -K single-role.yaml -e "playbook=playbooks/de-agave.yml agave_enabled=true"
```

Disable Agave:

```
$ ansible-playbook -i /path/to/inventory -K single-role.yaml -e "playbook=playbooks/de-agave.yml agave_enabled=false"
```
