### PR TITLE
metadata configuration cleanup

### DIFF
--- a/inventories/group_vars/all/db.yml
+++ b/inventories/group_vars/all/db.yml
@@ -20,8 +20,6 @@ jexdb_port: "{{db_port}}"
 jexdb_user: "{{db_user}}"
 jexdb_vendor: "{{db_vendor}}"
 
-metadata_db_driver: "{{ db_driver }}"
-metadata_db_vendor: "{{ db_vendor }}"
 metadata_db_host: "{{ db_host }}"
 metadata_db_port: "{{ db_port }}"
 metadata_db_user: "{{ db_user }}"
@@ -49,4 +47,3 @@ permissions_db_password: "{{ db_password }}"
 permissions_db_user: "{{ db_user }}"
 permissions_db_admin: "{{ db_admin }}"
 permissions_db_admin_password: "{{ db_admin_password }}"
-

--- a/roles/util-cfg-service/templates/metadata.properties.j2
+++ b/roles/util-cfg-service/templates/metadata.properties.j2
@@ -5,12 +5,11 @@ metadata.app.listen-port = {{ default_service_port }}
 metadata.app.environment-name = {{ environment_name }}
 
 # Database settings.
-metadata.db.subprotocol = {{ metadata_db_vendor }}
-metadata.db.host        = {{ metadata_db_host }}
-metadata.db.port        = {{ metadata_db_port }}
-metadata.db.name        = {{ metadata_db_name }}
-metadata.db.user        = {{ metadata_db_user }}
-metadata.db.password    = {{ metadata_db_password }}
+metadata.db.host     = {{ metadata_db_host }}
+metadata.db.port     = {{ metadata_db_port }}
+metadata.db.name     = {{ metadata_db_name }}
+metadata.db.user     = {{ metadata_db_user }}
+metadata.db.password = {{ metadata_db_password }}
 
 # AMQP settings
 metadata.amqp.uri                  = {{ amqp_de_uri }}

--- a/roles/util-cfg-service/templates/metadata.properties.j2
+++ b/roles/util-cfg-service/templates/metadata.properties.j2
@@ -5,7 +5,6 @@ metadata.app.listen-port = {{ default_service_port }}
 metadata.app.environment-name = {{ environment_name }}
 
 # Database settings.
-metadata.db.driver      = {{ metadata_db_driver }}
 metadata.db.subprotocol = {{ metadata_db_vendor }}
 metadata.db.host        = {{ metadata_db_host }}
 metadata.db.port        = {{ metadata_db_port }}


### PR DESCRIPTION
- Removed the unused `metadata.db.driver` setting
- Removed `metadata.db.subprotocol` so that the metadata service will always use the default subprotocol
